### PR TITLE
 fix "a space is required between consecutive right angle brackets (use '> >')"

### DIFF
--- a/src/hedder.hpp
+++ b/src/hedder.hpp
@@ -10,7 +10,7 @@ class Laplace
 {
     private:
         const int N=100;
-        std::vector<std::vector<double>> p;
+        std::vector<std::vector<double> > p;
         double dt;
         double lx;
         double ly;


### PR DESCRIPTION
## 事象
make する際にタイトルのエラーがでて実行できない

## 修正点
タイトルの通りに``` >> ``` を ``` > >``` に修正

## テスト
- [x] makeが 実行できる